### PR TITLE
Add basic CI jobs and infrastructure.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,128 @@
+---
+# Build the MSI installer.
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request: null
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Docker tag to use as base
+        default: latest
+        required: true
+concurrency:
+  group: build-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+jobs:
+  get-docker-tag:
+    name: Get Docker Tag
+    outputs:
+      tag: ${{ steps.prepare.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare Docker Tag
+        id: prepare
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "::set-output name=tag::${{ github.event.inputs.tag }}"
+          else
+            echo "::set-output name=tag::latest"
+          fi
+  prepare-tarball:
+    name: Prepare Tarball
+    needs:
+      - get-docker-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+      - name: Generate Tarball
+        id: generate
+        run: src/docker_image_to_wsl_tar.sh "${{ needs.get-docker-tag.outputs.tag }}"
+      - name: Store Tarball
+        id: store
+        uses: actions/upload-artifact@v3
+        with:
+          name: netdata-tarball
+          path: netdata.tar
+  build-msi:
+    name: Build MSI
+    needs:
+     - prepare-tarball
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v3
+      - name: Prepare Tools
+        id: prepare
+        run: choco install wixtoolset
+      - name: Fetch Tarball
+        id: fetch
+        uses: actions/download-artifact@v3
+        with:
+          name: netdata-tarball
+          path: src/
+      - name: Build MSI
+        id: build
+        working-directory: src
+        run: build_msi_with_wix_toolset.cmd
+      - name: Upload MSI
+        id: upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: netdata-msi
+          path: src/netdata.msi
+  prepare-release-tag:
+    name: Prepare Release Tag
+    if: ${{ github.event_name }} = "workflow_dispatch"
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Release Tag
+        id: tag
+        run: echo "::set-output name=tag::$(date +%F_%T | tr -d ':-_')"
+  get-netdata-version:
+    name: Get Netdata Version
+    if: ${{ github.event_name }} = "workflow_dispatch"
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    needs:
+      - get-docker-tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Image
+        id: fetch
+        run: docker pull "netdata/netdata:${{ needs.get-docker-tag.outputs.tag }}"
+      - name: Get Version
+        id: get-version
+        run: echo "::set-output name=version::$(podman run -it --rm --entrypoint /usr/sbin/netdata netdata/netdata -V 2>/dev/null | cut -f 2 -d ' ')"
+  release:
+    name: Create Release
+    if: ${{ github.event_name }} = "workflow_dispatch"
+    needs:
+      - build-msi
+      - prepare-release-tag
+      - get-netdata-version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch MSI
+        id: fetch
+        uses: actions/download-artifact@v3
+        with:
+          name: netdata-msi
+      - name: Create Release
+        id: release
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: false
+          artifactErrorsFailBuild: true
+          artifacts: 'netdata.msi'
+          body: With Netdata ${{ needs.get-netdata-version.outputs.version }}.
+          commit: HEAD
+          tag: ${{ needs.prepare-release-tag.outputs.tag }}
+          token: ${{ secrets.NETDATABOT_GITHUB_TOKEN }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,103 @@
+---
+# Runs various ReviewDog based checks against PR with suggested changes to improve quality
+name: Review
+on:
+  pull_request:
+    types: [opened, reopened, labeled, synchronize]
+env:
+  DISABLE_TELEMETRY: 1
+concurrency:
+  group: review-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  prep-review:
+    name: Prepare Review Jobs
+    runs-on: ubuntu-latest
+    outputs:
+      actionlint: ${{ steps.actionlint.outputs.run }}
+      shellcheck: ${{ steps.shellcheck.outputs.run }}
+      yamllint: ${{ steps.yamllint.outputs.run }}
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Check files for actionlint
+        id: actionlint
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/actionlint') }}" = "true" ]; then
+            echo '::set-output name=run::true'
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '\.github/workflows/.*' ; then
+            echo '::set-output name=run::true'
+            echo 'GitHub Actions workflows have changed, need to run actionlint.'
+          else
+            echo '::set-output name=run::false'
+          fi
+      - name: Check files for shellcheck
+        id: shellcheck
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/shellcheck') }}" = "true" ]; then
+            echo '::set-output name=run::true'
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.sh.*' ; then
+            echo '::set-output name=run::true'
+            echo 'Shell scripts have changed, need to run shellcheck.'
+          else
+            echo '::set-output name=run::false'
+          fi
+      - name: Check files for yamllint
+        id: yamllint
+        run: |
+          if [ "${{ contains(github.event.pull_request.labels.*.name, 'run-ci/yamllint') }}" = "true" ]; then
+            echo '::set-output name=run::true'
+          elif git diff --name-only origin/${{ github.base_ref }} HEAD | grep -Eq '.*\.ya?ml|python\.d/.*\.conf' ; then
+            echo '::set-output name=run::true'
+            echo 'YAML files have changed, need to run yamllint.'
+          else
+            echo '::set-output name=run::false'
+          fi
+
+  actionlint:
+    name: actionlint
+    needs: prep-review
+    if: needs.prep-review.outputs.actionlint == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+
+  shellcheck:
+    name: shellcheck
+    needs: prep-review
+    if: needs.prep-review.outputs.shellcheck == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+      - name: Run shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check
+          path: "."
+          pattern: "*.sh*"
+          exclude: "./.git/*"
+
+  yamllint:
+    name: yamllint
+    needs: prep-review
+    if: needs.prep-review.outputs.yamllint == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git clone repository
+        uses: actions/checkout@v3
+      - name: Run yamllint
+        uses: reviewdog/action-yamllint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-check

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,34 @@
+---
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: enable
+  hyphens: enable
+  indentation: enable
+  line-length:
+    max: 150
+    level: warning
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true
+  key-duplicates: enable
+  key-ordering: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    check-keys: false
+    allowed-values: ["true", "false", "yes", "no"]


### PR DESCRIPTION
- Adds a dependabot config to keep the GitHub Actions workflows up to date.
- Adds configuration for yamllint that is consistent with our YAML coding standards.
- Adds a basic CI review job that will run actionlint, shellcheck, and yamllint against PRs as appropriate.
- Modifies the shell script used to generate the WSL tarball from our Docker images to be consistent with BCP for shell scripts, and to accept the Docker tag to use as a base as a command line argument. Existing behavior should be unchanged.
- Adds a basic CI workflow to build the MSI package on PRs and pushes to master, storing the built package as an artifact on the workflow run. This workflow can also be triggered with a `workflow_dispatch` event, in which case it will prepare a GitHub release using the built MSI package.